### PR TITLE
Fix api to use passed params

### DIFF
--- a/twitter-openapi-typescript/src/apis/defaultApi.ts
+++ b/twitter-openapi-typescript/src/apis/defaultApi.ts
@@ -20,7 +20,7 @@ export class DefaultApiUtils {
     const apiFn: typeof param.apiFn = param.apiFn.bind(this.api);
     const response = await apiFn({
       queryId: this.flag[param.key]['queryId'],
-      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param }),
+      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param.param }),
       features: JSON.stringify(this.flag[param.key]['features']),
     });
     const data = param.convertFn(await response.value());

--- a/twitter-openapi-typescript/src/apis/tweetApi.ts
+++ b/twitter-openapi-typescript/src/apis/tweetApi.ts
@@ -75,7 +75,7 @@ export class TweetApiUtils {
     const apiFn: typeof param.apiFn = param.apiFn.bind(this.api);
     const response = await apiFn({
       queryId: this.flag[param.key]['queryId'],
-      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param }),
+      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param.param }),
       features: JSON.stringify(this.flag[param.key]['features']),
     });
     const instruction = param.convertFn(await response.value());

--- a/twitter-openapi-typescript/src/apis/userApi.ts
+++ b/twitter-openapi-typescript/src/apis/userApi.ts
@@ -20,7 +20,7 @@ export class UserApiUtils {
     const apiFn: typeof param.apiFn = param.apiFn.bind(this.api);
     const response = await apiFn({
       queryId: this.flag[param.key]['queryId'],
-      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param }),
+      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param.param }),
       features: JSON.stringify(this.flag[param.key]['features']),
     });
     const user = param.convertFn(await response.value());
@@ -33,7 +33,7 @@ export class UserApiUtils {
 
   async getUserByScreenName(param: getUserByScreenNameParam): Promise<UserApiUtilsResponse> {
     const args = {
-      screenName: param.screenName,
+      screen_name: param.screenName,
       ...param.extraParam,
     };
     const response = this.request({

--- a/twitter-openapi-typescript/src/apis/userListApi.ts
+++ b/twitter-openapi-typescript/src/apis/userListApi.ts
@@ -29,7 +29,7 @@ export class UserListApiUtils {
     const apiFn: typeof param.apiFn = param.apiFn.bind(this.api);
     const response = await apiFn({
       queryId: this.flag[param.key]['queryId'],
-      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param }),
+      variables: JSON.stringify({ ...this.flag[param.key]['variables'], ...param.param }),
       features: JSON.stringify(this.flag[param.key]['features']),
     });
     const instruction = param.convertFn(await response.value());


### PR DESCRIPTION
Currently, `twitter-openapi-typescript` constantly falls back to using the default values for all parameters no matter what you pass. The result is that you always get data about Elon Musk. This PR fixes that.