### PR TITLE
Allow overriding default options

### DIFF
--- a/twitter-openapi-typescript/src/api.ts
+++ b/twitter-openapi-typescript/src/api.ts
@@ -22,6 +22,10 @@ export type TwitterOpenApiCookie = {
   value: string;
 };
 
+export type TwitterOpenApiClientOptions = {
+  flag?: DefaultFlag;
+};
+
 export class TwitterOpenApi {
   static hash = 'd5ccc25869b68cbb39c68fa81a1fa77967a667da';
   static url = `https://raw.githubusercontent.com/fa0311/twitter-openapi/${this.hash}/src/config/placeholder.json`;
@@ -90,7 +94,7 @@ export class TwitterOpenApi {
     return context;
   }
 
-  async getClient(): Promise<TwitterOpenApiClient> {
+  async getClient(options?: TwitterOpenApiClientOptions): Promise<TwitterOpenApiClient> {
     const cookies: TwitterOpenApiCookie[] = await this.getGuestSession();
     const config: i.ConfigurationParameters = {
       fetchApi: this.fetchApi,
@@ -106,8 +110,10 @@ export class TwitterOpenApi {
       },
       accessToken: TwitterOpenApi.bearer,
     };
-    const flag = this.fetchApi(TwitterOpenApi.url, { method: 'GET' }).then((res) => res.json()) as Promise<DefaultFlag>;
-    return new TwitterOpenApiClient(new i.Configuration(config), await flag);
+    const flag =
+      options.flag ||
+      ((await this.fetchApi(TwitterOpenApi.url, { method: 'GET' }).then((res) => res.json())) as DefaultFlag);
+    return new TwitterOpenApiClient(new i.Configuration(config), flag);
   }
 
   async getClientFromCookies(ct0: string, authToken: string): Promise<TwitterOpenApiClient> {

--- a/twitter-openapi-typescript/src/api.ts
+++ b/twitter-openapi-typescript/src/api.ts
@@ -111,12 +111,16 @@ export class TwitterOpenApi {
       accessToken: TwitterOpenApi.bearer,
     };
     const flag =
-      options.flag ||
+      options?.flag ||
       ((await this.fetchApi(TwitterOpenApi.url, { method: 'GET' }).then((res) => res.json())) as DefaultFlag);
     return new TwitterOpenApiClient(new i.Configuration(config), flag);
   }
 
-  async getClientFromCookies(ct0: string, authToken: string): Promise<TwitterOpenApiClient> {
+  async getClientFromCookies(
+    ct0: string,
+    authToken: string,
+    options?: TwitterOpenApiClientOptions,
+  ): Promise<TwitterOpenApiClient> {
     const cookies: TwitterOpenApiCookie[] = await this.getGuestSession();
     [
       { name: 'auth_token', value: authToken },
@@ -139,8 +143,10 @@ export class TwitterOpenApi {
       },
       accessToken: TwitterOpenApi.bearer,
     };
-    const flag = this.fetchApi(TwitterOpenApi.url, { method: 'GET' }).then((res) => res.json()) as Promise<DefaultFlag>;
-    return new TwitterOpenApiClient(new i.Configuration(config), await flag);
+    const flag =
+      options?.flag ||
+      ((await this.fetchApi(TwitterOpenApi.url, { method: 'GET' }).then((res) => res.json())) as DefaultFlag);
+    return new TwitterOpenApiClient(new i.Configuration(config), flag);
   }
 }
 


### PR DESCRIPTION
Currently ` twitter-openapi-typescript` downloads and uses a placeholder.json file from a fixed location with no way to override it. This makes customizing the variables & features for each request really hard. I think it'd be a good idea to allow overriding the default placeholder.json file.

~In this PR, I have added a new `TwitterOpenApiClientOptions` which has an optional `flag` property allowing the user to change the defaults. There's also the added benefit of this approach where users won't have to make unnecessary requests to GitHub and just use the local placeholder.json.~

In this PR, I have added 3 new properties to `TwitterOpenApiParams`:

1. flag
2. accessToken
3. userAgent

This will make this library truly reusable and futureproof because I am 100% certain that Twitter will keep changing the access token so hard coding it is not a feasible option.